### PR TITLE
mcp tooling openai_usage_quota added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OpenAI Usage Quota Changelog
 
+## [0.5.0] - 2026-04-03
+- Access to usage quota with MCP tooling
+
 ## [0.4.1] - 2026-03-28
 - Expanded cake diagram icons to full 5% steps from 0% to 100%
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginName = OpenAI Usage Quota
 pluginRepositoryUrl = https://github.com/moritzf/openai-usage-quota-java
 
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.1
+pluginVersion = 0.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 253
@@ -17,12 +17,12 @@ platformVersion = 2025.3.3
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = com.intellij.mcpServer
 # Example: platformBundledModules = intellij.spellchecker
 platformBundledModules =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 9.3.1
+gradleVersion = 9.4.0
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/de/moritzf/quota/idea/QuotaUsageService.java
+++ b/src/main/java/de/moritzf/quota/idea/QuotaUsageService.java
@@ -53,6 +53,10 @@ public final class QuotaUsageService implements Disposable {
         AppExecutorUtil.getAppExecutorService().execute(this::refreshNow);
     }
 
+    public void refreshNowBlocking() {
+        refreshNow();
+    }
+
     private void scheduleRefresh() {
         int minutes = Math.max(1, QuotaSettingsState.getInstance().refreshMinutes);
         scheduled = scheduler.scheduleWithFixedDelay(this::refreshNow, 0, minutes, TimeUnit.MINUTES);

--- a/src/main/java/de/moritzf/quota/idea/mcp/OpenAiUsageQuotaMcpToolset.java
+++ b/src/main/java/de/moritzf/quota/idea/mcp/OpenAiUsageQuotaMcpToolset.java
@@ -1,0 +1,57 @@
+package de.moritzf.quota.idea.mcp;
+
+import com.intellij.mcpserver.McpToolset;
+import com.intellij.mcpserver.McpToolCallResult;
+import com.intellij.mcpserver.McpToolCallResultContent;
+import com.intellij.mcpserver.annotations.McpDescription;
+import com.intellij.mcpserver.annotations.McpTool;
+import de.moritzf.quota.idea.QuotaUsageService;
+
+/**
+ * Exposes the latest OpenAI usage JSON through IntelliJ's MCP server.
+ */
+public final class OpenAiUsageQuotaMcpToolset implements McpToolset {
+    @McpTool(name = "openai_usage_quota")
+    @McpDescription(description = "Returns the latest OpenAI usage quota response JSON.")
+    public McpToolCallResult openai_usage_quota() {
+        QuotaUsageService usageService = QuotaUsageService.getInstance();
+        usageService.refreshNowBlocking();
+
+        String error = usageService.getLastError();
+        if (error != null && !error.isBlank()) {
+            return errorResult(error);
+        }
+
+        String json = usageService.getLastResponseJson();
+        if (json == null || json.isBlank()) {
+            return errorResult("No usage response available");
+        }
+        return successResult(json);
+    }
+
+    private static McpToolCallResult successResult(String text) {
+        return new McpToolCallResult(
+                new McpToolCallResultContent[]{new McpToolCallResultContent.Text(text)},
+                null,
+                false
+        );
+    }
+
+    private static McpToolCallResult errorResult(String errorMessage) {
+        String errorJson = "{\"error\":\"" + escapeJson(errorMessage) + "\"}";
+        return new McpToolCallResult(
+                new McpToolCallResultContent[]{new McpToolCallResultContent.Text(errorJson)},
+                null,
+                true
+        );
+    }
+
+    private static String escapeJson(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n")
+                .replace("\t", "\\t");
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>de.moritzf.openai-usage-quota</id>
     <name>OpenAI Usage Quota</name>
-    <version>0.2.0</version>
+    <version>0.5.0</version>
     <vendor>Moritz</vendor>
 
     <description>
@@ -9,6 +9,7 @@
     </description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.mcpServer</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationConfigurable
@@ -16,5 +17,6 @@
                 displayName="OpenAI Usage Quota"
                 instance="de.moritzf.quota.idea.QuotaSettingsConfigurable"/>
         <statusBarWidgetFactory implementation="de.moritzf.quota.idea.QuotaStatusBarWidgetFactory" id="openai.usage.quota.widget"/>
+        <mcpServer.mcpToolset implementation="de.moritzf.quota.idea.mcp.OpenAiUsageQuotaMcpToolset"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Hi, ich hab das angekündigte MCP openai_usage_quota eingebaut. In AGENTS.md kann dann sowas rein:

```
## Auslastung
Bei potenziell token-intensiven Aufgaben (längere Analysen, große Codeänderungen, mehrere Tool-Aufrufe) und zu Beginn eines Chats:
1. Rufe zuerst das MCP-Tool `openai_usage_quota` (ohne Parameter) auf.
2. Wenn die Auslastung > 95 % ist, warte 10 Minuten ohne Timeout und prüfe erneut.
3. Wiederhole das maximal 5 Stunden lang oder bis die Auslastung < 60 % ist.
4. Gib pro Prüfung eine kurze Statuszeile aus (Auslastung, verbleibend, nächster Check).
5. Bei Tool-Fehler (`error` im JSON): Fehler kurz ausgeben und ohne Warteschleife fortfahren.
```
